### PR TITLE
update dependabot-automerge.yml to work with recent GitHub changes (08-03-2021

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -4,18 +4,14 @@
 name: Auto-Merge Dependabot PRs
 
 on:
-  pull_request:
+  pull_request_target:
 
 jobs:
   auto-merge:
+    if: github.actor == 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-
-      - name: Check if PR should be auto-merged
-        uses: ahmadnassri/action-dependabot-auto-merge@v2
+      - uses: ahmadnassri/action-dependabot-auto-merge@v2
         with:
+          target: minor
           github-token: ${{ secrets.AUTO_MERGE_TOKEN }}
-          # By default, squash and merge, so Github chooses nice commit messages
-          command: squash and merge


### PR DESCRIPTION
Based on recent changes, the current workflow does no allow to be used on public repository anymore (recent change on 8-march by GiHub).

This modification works and is in line with issues mention at the published workflow.
(see related issue and fix https://github.com/ahmadnassri/action-dependabot-auto-merge/issues/60#issuecomment-801338428)

Working and tested implementation can be reviewed at my organization https://github.com/drozmotiX/
(all adapters used this flow now)