### PR TITLE
feat: implement yarn v2+ workspace mode

### DIFF
--- a/build/release.js
+++ b/build/release.js
@@ -35,19 +35,9 @@ var __importStar = (this && this.__importStar) || function (mod) {
     __setModuleDefault(result, mod);
     return result;
 };
-var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
-    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
-    return new (P || (P = Promise))(function (resolve, reject) {
-        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
-        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
-    });
-};
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
-var _a, _b;
 Object.defineProperty(exports, "__esModule", { value: true });
 /* eslint-disable @typescript-eslint/no-var-requires */
 const strings_1 = require("alcalzone-shared/strings");
@@ -62,193 +52,200 @@ const tools_1 = require("./tools");
 const translate_1 = require("./translate");
 const parseArgs_1 = require("./parseArgs");
 const gitStatus_1 = require("./gitStatus");
-const rootDir = process.cwd();
-const argv = yargs_1.default.parseSync();
-function fail(reason) {
-    console.error("");
-    console.error(safe_1.default.red("ERROR: " + reason));
-    console.error("");
-    process.exit(1);
-}
-// ensure that package.json exists and has a version (in lerna mode)
-const packPath = path.join(rootDir, "package.json");
-if (!fs.existsSync(packPath)) {
-    fail("No package.json found in the current directory!");
-}
-const pack = require(packPath);
-if (!parseArgs_1.lerna && !(pack === null || pack === void 0 ? void 0 : pack.version)) {
-    fail("Missing property version from package.json!");
-}
-const lernaPath = path.join(rootDir, "lerna.json");
-if (parseArgs_1.lerna && !fs.existsSync(lernaPath)) {
-    fail("No lerna.json found in the current directory!");
-}
-let lernaJson;
-if (parseArgs_1.lerna) {
-    lernaJson = require(lernaPath);
-    if (!lernaJson.version) {
-        fail("Missing property version from lerna.json!");
+const yarn_1 = require("./yarn");
+(async () => {
+    var _a, _b;
+    const rootDir = process.cwd();
+    const argv = yargs_1.default.parseSync();
+    const { allChanges, isDryRun, yarnWorkspace, lerna, lernaCheck, scripts: userScripts, remote, } = await parseArgs_1.parseArgs();
+    function fail(reason) {
+        console.error("");
+        console.error(safe_1.default.red("ERROR: " + reason));
+        console.error("");
+        process.exit(1);
     }
-}
-// If this is an ioBroker project, also bump the io-package.json
-const ioPackPath = path.join(rootDir, "io-package.json");
-const hasIoPack = fs.existsSync(ioPackPath);
-const ioPack = hasIoPack ? require(ioPackPath) : undefined;
-if (!parseArgs_1.lerna && hasIoPack && !((_a = ioPack === null || ioPack === void 0 ? void 0 : ioPack.common) === null || _a === void 0 ? void 0 : _a.version)) {
-    fail("Missing property common.version from io-package.json!");
-}
-// Assume the repo is managed with yarn if there is a yarn.lock
-const isYarn = fs.existsSync(path.join(rootDir, "yarn.lock"));
-// Try to find the changelog
-let isChangelogInReadme = false;
-let CHANGELOG_PLACEHOLDER_PREFIX = "##";
-const changelogPath = path.join(rootDir, "CHANGELOG.md");
-const readmePath = path.join(rootDir, "README.md");
-/** Can also be the readme! */
-let changelog;
-let changelogFilename;
-if (!fs.existsSync(changelogPath)) {
-    // The changelog might be in the readme
-    if (!fs.existsSync(readmePath)) {
-        fail("No CHANGELOG.md or README.md found in the current directory!");
+    // ensure that package.json exists and has a version (in lerna mode)
+    const packPath = path.join(rootDir, "package.json");
+    if (!fs.existsSync(packPath)) {
+        fail("No package.json found in the current directory!");
     }
-    isChangelogInReadme = true;
-    changelog = fs.readFileSync(readmePath, "utf8");
-    changelogFilename = path.basename(readmePath);
-    // The changelog is indented one more level in the readme
-    CHANGELOG_PLACEHOLDER_PREFIX += "#";
-}
-else {
-    changelog = fs.readFileSync(changelogPath, "utf8");
-    changelogFilename = path.basename(changelogPath);
-}
-// CHANGELOG_OLD is only used if the main changelog is in the readme
-const changelogOldPath = path.join(rootDir, "CHANGELOG_OLD.md");
-const hasChangelogOld = isChangelogInReadme && fs.existsSync(changelogOldPath);
-const CHANGELOG_MARKERS = ["**WORK IN PROGRESS**", "__WORK IN PROGRESS__"];
-const CHANGELOG_PLACEHOLDER = `${CHANGELOG_PLACEHOLDER_PREFIX} ${CHANGELOG_MARKERS[0]}`;
-// The regex for the placeholder includes an optional free text at the end, e.g.
-// ### __WORK IN PROGRESS__ "2020 Doomsday release"
-const CHANGELOG_PLACEHOLDER_REGEX = new RegExp(`^${CHANGELOG_PLACEHOLDER_PREFIX} (?:${CHANGELOG_MARKERS.map(m => m.replace(/\*/g, "\\*")).join("|")})(.*?)$`, "gm");
-// check if the changelog contains exactly 1 occurence of the changelog placeholder
-switch ((changelog.match(CHANGELOG_PLACEHOLDER_REGEX) || []).length) {
-    case 0:
-        fail(safe_1.default.red(`Cannot continue, the changelog placeholder is missing from ${changelogFilename}!\n` +
-            "Please add the following line to your changelog:\n" +
-            CHANGELOG_PLACEHOLDER));
-    case 1:
-        break; // all good
-    default:
-        fail(safe_1.default.red(`Cannot continue, there is more than one changelog placeholder in ${changelogFilename}!`));
-}
-// Check if there is a changelog for the current version
-const currentChangelog = tools_1.extractCurrentChangelog(changelog, CHANGELOG_PLACEHOLDER_PREFIX, CHANGELOG_PLACEHOLDER_REGEX);
-if (!currentChangelog) {
-    fail(safe_1.default.red("Cannot continue, the changelog for the next version is empty!"));
-}
-// check if there are untracked changes
-const branchStatus = gitStatus_1.gitStatus(rootDir);
-if (branchStatus === "diverged") {
-    if (!parseArgs_1.isDryRun) {
-        fail(safe_1.default.red("Cannot continue, both the remote and the local repo have different changes! Please merge the remote changes first."));
+    const pack = require(packPath);
+    if (!lerna && !(pack === null || pack === void 0 ? void 0 : pack.version)) {
+        fail("Missing property version from package.json!");
+    }
+    const lernaPath = path.join(rootDir, "lerna.json");
+    if (lerna && !fs.existsSync(lernaPath)) {
+        fail("No lerna.json found in the current directory!");
+    }
+    let lernaJson;
+    if (lerna) {
+        lernaJson = require(lernaPath);
+        if (!lernaJson.version) {
+            fail("Missing property version from lerna.json!");
+        }
+    }
+    // If this is an ioBroker project, also bump the io-package.json
+    const ioPackPath = path.join(rootDir, "io-package.json");
+    const hasIoPack = fs.existsSync(ioPackPath);
+    const ioPack = hasIoPack ? require(ioPackPath) : undefined;
+    if (!lerna && hasIoPack && !((_a = ioPack === null || ioPack === void 0 ? void 0 : ioPack.common) === null || _a === void 0 ? void 0 : _a.version)) {
+        fail("Missing property common.version from io-package.json!");
+    }
+    // Assume the repo is managed with yarn if there is a yarn.lock
+    const isYarn = fs.existsSync(path.join(rootDir, "yarn.lock"));
+    // Try to find the changelog
+    let isChangelogInReadme = false;
+    let CHANGELOG_PLACEHOLDER_PREFIX = "##";
+    const changelogPath = path.join(rootDir, "CHANGELOG.md");
+    const readmePath = path.join(rootDir, "README.md");
+    /** Can also be the readme! */
+    let changelog;
+    let changelogFilename;
+    if (!fs.existsSync(changelogPath)) {
+        // The changelog might be in the readme
+        if (!fs.existsSync(readmePath)) {
+            fail("No CHANGELOG.md or README.md found in the current directory!");
+        }
+        isChangelogInReadme = true;
+        changelog = fs.readFileSync(readmePath, "utf8");
+        changelogFilename = path.basename(readmePath);
+        // The changelog is indented one more level in the readme
+        CHANGELOG_PLACEHOLDER_PREFIX += "#";
     }
     else {
-        console.log(safe_1.default.red("This is a dry run. The full run would fail due to a diverged branch\n"));
+        changelog = fs.readFileSync(changelogPath, "utf8");
+        changelogFilename = path.basename(changelogPath);
     }
-}
-else if (branchStatus === "behind") {
-    if (!parseArgs_1.isDryRun) {
-        fail(safe_1.default.red(`Cannot continue, the local branch is behind the remote changes! Please include them first, e.g. with "git pull".`));
+    // CHANGELOG_OLD is only used if the main changelog is in the readme
+    const changelogOldPath = path.join(rootDir, "CHANGELOG_OLD.md");
+    const hasChangelogOld = isChangelogInReadme && fs.existsSync(changelogOldPath);
+    const CHANGELOG_MARKERS = [
+        "**WORK IN PROGRESS**",
+        "__WORK IN PROGRESS__",
+    ];
+    const CHANGELOG_PLACEHOLDER = `${CHANGELOG_PLACEHOLDER_PREFIX} ${CHANGELOG_MARKERS[0]}`;
+    // The regex for the placeholder includes an optional free text at the end, e.g.
+    // ### __WORK IN PROGRESS__ "2020 Doomsday release"
+    const CHANGELOG_PLACEHOLDER_REGEX = new RegExp(`^${CHANGELOG_PLACEHOLDER_PREFIX} (?:${CHANGELOG_MARKERS.map((m) => m.replace(/\*/g, "\\*")).join("|")})(.*?)$`, "gm");
+    // check if the changelog contains exactly 1 occurence of the changelog placeholder
+    switch ((changelog.match(CHANGELOG_PLACEHOLDER_REGEX) || []).length) {
+        case 0:
+            fail(safe_1.default.red(`Cannot continue, the changelog placeholder is missing from ${changelogFilename}!\n` +
+                "Please add the following line to your changelog:\n" +
+                CHANGELOG_PLACEHOLDER));
+        case 1:
+            break; // all good
+        default:
+            fail(safe_1.default.red(`Cannot continue, there is more than one changelog placeholder in ${changelogFilename}!`));
     }
-    else {
-        console.log(safe_1.default.red("This is a dry run. The full run would fail due to the local branch being behind\n"));
+    // Check if there is a changelog for the current version
+    const currentChangelog = tools_1.extractCurrentChangelog(changelog, CHANGELOG_PLACEHOLDER_PREFIX, CHANGELOG_PLACEHOLDER_REGEX);
+    if (!currentChangelog) {
+        fail(safe_1.default.red("Cannot continue, the changelog for the next version is empty!"));
     }
-}
-else if (branchStatus === "ahead" || branchStatus === "up-to-date") {
-    // all good
-    if (!parseArgs_1.lerna) {
-        console.log(safe_1.default.green("git status is good - I can continue..."));
+    // check if there are untracked changes
+    const branchStatus = gitStatus_1.gitStatus(rootDir, remote);
+    if (branchStatus === "diverged") {
+        if (!isDryRun) {
+            fail(safe_1.default.red("Cannot continue, both the remote and the local repo have different changes! Please merge the remote changes first."));
+        }
+        else {
+            console.log(safe_1.default.red("This is a dry run. The full run would fail due to a diverged branch\n"));
+        }
     }
-}
-else if (branchStatus === "uncommitted" && !parseArgs_1.lerna) {
-    if (!parseArgs_1.isDryRun && !parseArgs_1.allChanges) {
-        fail(safe_1.default.red(`Cannot continue, the local branch has uncommitted changes! Add them to a separate commit first or add the "--all" option to include them in the release commit.`));
+    else if (branchStatus === "behind") {
+        if (!isDryRun) {
+            fail(safe_1.default.red(`Cannot continue, the local branch is behind the remote changes! Please include them first, e.g. with "git pull".`));
+        }
+        else {
+            console.log(safe_1.default.red("This is a dry run. The full run would fail due to the local branch being behind\n"));
+        }
     }
-    else {
-        if (parseArgs_1.allChanges) {
-            console.warn(safe_1.default.yellow(`Your branch has uncommitted changes that will be included in the release commit!
+    else if (branchStatus === "ahead" || branchStatus === "up-to-date") {
+        // all good
+        if (!lerna) {
+            console.log(safe_1.default.green("git status is good - I can continue..."));
+        }
+    }
+    else if (branchStatus === "uncommitted" && !lerna) {
+        if (!isDryRun && !allChanges) {
+            fail(safe_1.default.red(`Cannot continue, the local branch has uncommitted changes! Add them to a separate commit first or add the "--all" option to include them in the release commit.`));
+        }
+        else {
+            if (allChanges) {
+                console.warn(safe_1.default.yellow(`Your branch has uncommitted changes that will be included in the release commit!
 Consider adding them to a separate commit first.
 `));
-        }
-        else {
-            console.log(safe_1.default.red(`This is a dry run. The full run would fail due to uncommitted changes.
+            }
+            else {
+                console.log(safe_1.default.red(`This is a dry run. The full run would fail due to uncommitted changes.
 Add them to a separate commit first or add the "--all" option to include them in the release commit.
 `));
+            }
         }
     }
-}
-// All the necessary checks are done, exit
-if (parseArgs_1.lernaCheck)
-    process.exit(0);
-const releaseTypes = [
-    "major",
-    "premajor",
-    "minor",
-    "preminor",
-    "patch",
-    "prepatch",
-    "prerelease",
-];
-const releaseType = (argv._[0] || "patch").toString();
-if (!parseArgs_1.lerna && releaseType.startsWith("--")) {
-    fail(`Invalid release type ${releaseType}. If you meant to pass hyphenated args, try again without the single "--".`);
-}
-let newVersion;
-if (parseArgs_1.lerna) {
-    newVersion = lernaJson.version;
-}
-else {
-    // Find the highest current version
-    let oldVersion = pack.version;
-    if (hasIoPack &&
-        semver.valid(ioPack.common.version) &&
-        semver.gt(ioPack.common.version, oldVersion)) {
-        oldVersion = ioPack.common.version;
+    // All the necessary checks are done, exit
+    if (lernaCheck)
+        process.exit(0);
+    const releaseTypes = [
+        "major",
+        "premajor",
+        "minor",
+        "preminor",
+        "patch",
+        "prepatch",
+        "prerelease",
+    ];
+    const releaseType = (argv._[0] || "patch").toString();
+    if (!lerna && releaseType.startsWith("--")) {
+        fail(`Invalid release type ${releaseType}. If you meant to pass hyphenated args, try again without the single "--".`);
     }
-    if (releaseTypes.indexOf(releaseType) > -1) {
-        if (releaseType.startsWith("pre") && argv._.length >= 2) {
-            // increment to pre-release with an additional prerelease string
-            newVersion = semver.inc(oldVersion, releaseType, (_b = argv._[1]) === null || _b === void 0 ? void 0 : _b.toString());
-        }
-        else {
-            newVersion = semver.inc(oldVersion, releaseType);
-        }
-        console.log(`bumping version ${safe_1.default.blue(oldVersion)} to ${safe_1.default.gray(releaseType)} version ${safe_1.default.green(newVersion)}\n`);
+    let newVersion;
+    if (lerna) {
+        newVersion = lernaJson.version;
     }
     else {
-        // increment to specific version
-        newVersion = semver.clean(releaseType);
-        if (newVersion == null) {
-            fail(`invalid version string "${newVersion}"`);
+        // Find the highest current version
+        let oldVersion = pack.version;
+        if (hasIoPack &&
+            semver.valid(ioPack.common.version) &&
+            semver.gt(ioPack.common.version, oldVersion)) {
+            oldVersion = ioPack.common.version;
+        }
+        if (releaseTypes.indexOf(releaseType) > -1) {
+            if (releaseType.startsWith("pre") && argv._.length >= 2) {
+                // increment to pre-release with an additional prerelease string
+                newVersion = semver.inc(oldVersion, releaseType, (_b = argv._[1]) === null || _b === void 0 ? void 0 : _b.toString());
+            }
+            else {
+                newVersion = semver.inc(oldVersion, releaseType);
+            }
+            console.log(`bumping version ${safe_1.default.blue(oldVersion)} to ${safe_1.default.gray(releaseType)} version ${safe_1.default.green(newVersion)}\n`);
         }
         else {
-            // valid version string => check if its actually newer
-            if (!semver.gt(newVersion, pack.version)) {
-                fail(`new version ${newVersion} is NOT > than package.json version ${pack.version}`);
+            // increment to specific version
+            newVersion = semver.clean(releaseType);
+            if (newVersion == null) {
+                fail(`invalid version string "${newVersion}"`);
             }
-            if (hasIoPack && !semver.gt(newVersion, ioPack.common.version)) {
-                fail(`new version ${newVersion} is NOT > than io-package.json version ${ioPack.common.version}`);
+            else {
+                // valid version string => check if its actually newer
+                if (!semver.gt(newVersion, pack.version)) {
+                    fail(`new version ${newVersion} is NOT > than package.json version ${pack.version}`);
+                }
+                if (hasIoPack &&
+                    !semver.gt(newVersion, ioPack.common.version)) {
+                    fail(`new version ${newVersion} is NOT > than io-package.json version ${ioPack.common.version}`);
+                }
             }
+            console.log(`bumping version ${oldVersion} to specific version ${newVersion}`);
         }
-        console.log(`bumping version ${oldVersion} to specific version ${newVersion}`);
     }
-}
-(() => __awaiter(void 0, void 0, void 0, function* () {
-    if (parseArgs_1.isDryRun) {
+    if (isDryRun) {
         console.log(safe_1.default.yellow("dry run:") + " not updating package files");
     }
     else {
-        if (!parseArgs_1.lerna) {
+        if (!lerna && !yarnWorkspace) {
             console.log(`updating package.json from ${safe_1.default.blue(pack.version)} to ${safe_1.default.green(newVersion)}`);
             pack.version = newVersion;
             fs.writeFileSync(packPath, JSON.stringify(pack, null, 2));
@@ -292,7 +289,7 @@ ${newChangelog}`);
             else {
                 console.log(`adding new news to io-package.json...`);
                 try {
-                    const translated = yield translate_1.translateText(newChangelog);
+                    const translated = await translate_1.translateText(newChangelog);
                     ioPack.common.news = tools_1.prependKey(ioPack.common.news, newVersion, translated);
                 }
                 catch (e) {
@@ -308,28 +305,45 @@ ${newChangelog}`);
             fs.writeFileSync(ioPackPath, JSON.stringify(ioPack, null, 4));
         }
     }
-    const execQueue = parseArgs_1.lerna
+    let changedWorkspaces = [];
+    if (yarnWorkspace) {
+        changedWorkspaces = await yarn_1.getChangedWorkspaces();
+        if (!changedWorkspaces.length) {
+            fail("No changed workspaces detected!");
+        }
+    }
+    const execQueue = (lerna
         ? [
             `git add -A -- ":(exclude).commitmessage"`,
             `git commit -F ".commitmessage" --no-verify`,
             // lerna does the rest for us
         ]
         : [
+            ...(yarnWorkspace
+                ? [
+                    ...changedWorkspaces.map((ws) => `yarn workspace ${ws} version ${newVersion} --deferred`),
+                    `yarn version apply --all`,
+                ]
+                : []),
             isYarn ? `yarn install` : `npm install`,
             `git add -A -- ":(exclude).commitmessage"`,
             `git commit -F ".commitmessage"`,
-            `git tag v${newVersion}`,
-            `git push${parseArgs_1.remote ? ` ${parseArgs_1.remote.split("/").join(" ")}` : ""}`,
-            `git push${parseArgs_1.remote ? ` ${parseArgs_1.remote.split("/").join(" ")}` : ""} --tags`,
-        ];
+            `git tag -a v${newVersion} -m "v${newVersion}"`,
+            // `git push${
+            // 	remote ? ` ${remote.split("/").join(" ")}` : ""
+            // }`,
+            // `git push${
+            // 	remote ? ` ${remote.split("/").join(" ")}` : ""
+            // } --tags`,
+        ]).filter((cmd) => !!cmd);
     // Execute user scripts before pushing
-    if (typeof parseArgs_1.scripts.beforePush === "string") {
-        execQueue.unshift(parseArgs_1.scripts.beforePush);
+    if (typeof userScripts.beforePush === "string") {
+        execQueue.unshift(userScripts.beforePush);
     }
-    else if (typeguards_1.isArray(parseArgs_1.scripts.beforePush)) {
-        execQueue.unshift(...parseArgs_1.scripts.beforePush);
+    else if (typeguards_1.isArray(userScripts.beforePush)) {
+        execQueue.unshift(...userScripts.beforePush);
     }
-    if (parseArgs_1.isDryRun) {
+    if (isDryRun) {
         console.log(safe_1.default.yellow("dry run:") + " I would execute this:");
         for (const command of execQueue) {
             console.log("  " + command);
@@ -352,7 +366,7 @@ ${newChangelog}`);
     console.log(safe_1.default.green("done!"));
     console.log("");
     process.exit(0);
-}))().catch((e) => {
+})().catch((e) => {
     console.error(e);
     process.exit(1);
 });

--- a/build/translate.js
+++ b/build/translate.js
@@ -18,15 +18,6 @@ var __importStar = (this && this.__importStar) || function (mod) {
     __setModuleDefault(result, mod);
     return result;
 };
-var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
-    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
-    return new (P || (P = Promise))(function (resolve, reject) {
-        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
-        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
-    });
-};
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
@@ -36,21 +27,19 @@ const axios_1 = __importDefault(require("axios"));
 const qs = __importStar(require("querystring"));
 const url = "https://translator.iobroker.in/translator";
 /** Takes an english text and translates it into multiple languages */
-function translateText(textEN) {
-    return __awaiter(this, void 0, void 0, function* () {
-        const data = qs.stringify({
-            text: textEN,
-            together: true,
-        });
-        const response = yield axios_1.default({
-            method: "post",
-            url,
-            data,
-            headers: {
-                "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8",
-            },
-        });
-        return response.data;
+async function translateText(textEN) {
+    const data = qs.stringify({
+        text: textEN,
+        together: true,
     });
+    const response = await axios_1.default({
+        method: "post",
+        url,
+        data,
+        headers: {
+            "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8",
+        },
+    });
+    return response.data;
 }
 exports.translateText = translateText;

--- a/build/yarn.js
+++ b/build/yarn.js
@@ -1,0 +1,54 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.bump = exports.getChangedWorkspaces = exports.isYarnWorkspace = void 0;
+const typeguards_1 = require("alcalzone-shared/typeguards");
+const execa_1 = __importDefault(require("execa"));
+const fs_extra_1 = __importDefault(require("fs-extra"));
+const path_1 = __importDefault(require("path"));
+const semver_1 = __importDefault(require("semver"));
+/**
+ * Tests if the current workspace is using yarn with the version and workspace-tools plugin,
+ * which can be used to bump the versions
+ */
+async function isYarnWorkspace() {
+    // There should be a yarn.lock or yarn is not used
+    if (!(await fs_extra_1.default.pathExists(path_1.default.join(process.cwd(), "yarn.lock")))) {
+        return false;
+    }
+    // package.json should contain a workspaces field
+    const packageJson = await fs_extra_1.default.readJSON(path_1.default.join(process.cwd(), "package.json"), { encoding: "utf8" });
+    if (!("workspaces" in packageJson && typeguards_1.isArray(packageJson.workspaces))) {
+        return false;
+    }
+    // Check if yarn is used in at least version 2
+    const { stdout: yarnVersion } = await execa_1.default("yarn", ["-v"], {
+        reject: false,
+    });
+    if (!semver_1.default.valid(yarnVersion) || semver_1.default.lt(yarnVersion, "2.0.0")) {
+        return false;
+    }
+    // Check that the version plugin is there
+    const { stdout: plugins } = await execa_1.default("yarn", ["plugin", "runtime", "--json"], {
+        reject: false,
+    });
+    return (plugins.includes(`"@yarnpkg/plugin-version"`) &&
+        plugins.includes(`"@yarnpkg/plugin-workspace-tools"`));
+}
+exports.isYarnWorkspace = isYarnWorkspace;
+async function getChangedWorkspaces() {
+    const { stdout: checkResult } = await execa_1.default("yarn", ["version", "check"], {
+        reject: false,
+    });
+    const matches = [
+        ...checkResult.matchAll(/ (?<workspace>@?[^ ]*?)@.+ has been modified but/g),
+    ].map((match) => match.groups.workspace);
+    return matches;
+}
+exports.getChangedWorkspaces = getChangedWorkspaces;
+async function bump(workspace, type) {
+    await execa_1.default("yarn", ["workspace", workspace, "version", type]);
+}
+exports.bump = bump;

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,21 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@tsconfig/node12": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.9.tgz",
+      "integrity": "sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==",
+      "dev": true
+    },
+    "@types/fs-extra": {
+      "version": "9.0.11",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.11.tgz",
+      "integrity": "sha512-mZsifGG4QeQ7hlkhO56u7zt/ycBgGxSVsFI/6lGTU34VtwkiqrrSDgw0+ygs8kFGWcXnFQWMrzF2h7TtDFNixA==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/node": {
       "version": "15.12.4",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-15.12.4.tgz",
@@ -88,6 +103,16 @@
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
       "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA=="
     },
+    "cross-spawn": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "requires": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      }
+    },
     "debug": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
@@ -106,20 +131,80 @@
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
       "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw=="
     },
+    "execa": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "requires": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      }
+    },
     "follow-redirects": {
       "version": "1.13.1",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.1.tgz",
       "integrity": "sha512-SSG5xmZh1mkPGyKzjZP8zLjltIfpW32Y5QpdNJyjcfGxK3qo3NDDkZOZSFiGn1A6SclQxY9GzEwAHQ3dmYRWpg=="
+    },
+    "fs-extra": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
+      "integrity": "sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==",
+      "requires": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      }
     },
     "get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
     },
+    "get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg=="
+    },
+    "graceful-fs": {
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
+      "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ=="
+    },
+    "human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw=="
+    },
     "is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+    },
+    "is-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
+      "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw=="
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+    },
+    "jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "requires": {
+        "graceful-fs": "^4.1.6",
+        "universalify": "^2.0.0"
+      }
     },
     "lru-cache": {
       "version": "6.0.0",
@@ -129,10 +214,41 @@
         "yallist": "^4.0.0"
       }
     },
+    "merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="
+    },
+    "mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
+    },
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
+    "npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "requires": {
+        "path-key": "^3.0.0"
+      }
+    },
+    "onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "requires": {
+        "mimic-fn": "^2.1.0"
+      }
+    },
+    "path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
     },
     "require-directory": {
       "version": "2.1.1",
@@ -146,6 +262,24 @@
       "requires": {
         "lru-cache": "^6.0.0"
       }
+    },
+    "shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "requires": {
+        "shebang-regex": "^3.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
+    },
+    "signal-exit": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
+      "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
     },
     "string-width": {
       "version": "4.2.2",
@@ -165,11 +299,29 @@
         "ansi-regex": "^5.0.0"
       }
     },
+    "strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA=="
+    },
     "typescript": {
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.4.tgz",
       "integrity": "sha512-uauPG7XZn9F/mo+7MrsRjyvbxFpzemRjKEZXS4AK83oP2KKOJPvb+9cO/gmnv8arWZvhnjVOXz7B49m1l0e9Ew==",
       "dev": true
+    },
+    "universalify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
+    },
+    "which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "requires": {
+        "isexe": "^2.0.0"
+      }
     },
     "wrap-ansi": {
       "version": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,8 @@
   },
   "homepage": "https://github.com/AlCalzone/release-script#readme",
   "devDependencies": {
+    "@tsconfig/node12": "^1.0.9",
+    "@types/fs-extra": "^9.0.11",
     "@types/node": "^15.12.4",
     "@types/semver": "^7.3.6",
     "@types/yargs": "^17.0.0",
@@ -39,6 +41,8 @@
     "alcalzone-shared": "^4.0.0",
     "axios": "^0.21.1",
     "colors": "^1.4.0",
+    "execa": "^5.1.1",
+    "fs-extra": "^10.0.0",
     "semver": "^7.3.5",
     "yargs": "^17.0.1"
   },

--- a/src/gitStatus.ts
+++ b/src/gitStatus.ts
@@ -1,5 +1,4 @@
 import { execSync, ExecOptions } from "child_process";
-import { remote } from "./parseArgs";
 
 type GitStatus = "diverged" | "uncommitted" | "behind" | "ahead" | "up-to-date";
 
@@ -14,7 +13,7 @@ function getUpstream(cwd: string): string {
 	).trim();
 }
 
-function getCommitDifferences(cwd: string): [local: number, remote: number] {
+function getCommitDifferences(cwd: string, remote?: string): [localDiff: number, remoteDiff: number] {
 	// if upstream hard configured we use it
 	const output = execSync(
 		`git rev-list --left-right --count HEAD...${remote || getUpstream(cwd)}`,
@@ -33,16 +32,16 @@ function hasUncommittedChanges(cwd: string): boolean {
 }
 
 /** Locale-independent check for uncommitted changes and commit differences between local and remote branches */
-export function gitStatus(cwd: string): GitStatus {
-	const [local, remote] = getCommitDifferences(cwd);
-	if (local > 0 && remote > 0) {
+export function gitStatus(cwd: string, remote?: string): GitStatus {
+	const [localDiff, remoteDiff] = getCommitDifferences(cwd, remote);
+	if (localDiff > 0 && remoteDiff > 0) {
 		return "diverged";
-	} else if (local === 0 && remote > 0) {
+	} else if (localDiff === 0 && remoteDiff > 0) {
 		return "behind";
 	} else if (hasUncommittedChanges(cwd)) {
 		return "uncommitted";
 	} /* if (remote === 0) */ else {
-		return local === 0 ? "up-to-date" : "ahead";
+		return localDiff === 0 ? "up-to-date" : "ahead";
 	}
 }
 

--- a/src/parseArgs.ts
+++ b/src/parseArgs.ts
@@ -2,36 +2,41 @@ import yargs from "yargs";
 import * as fs from "fs";
 import * as path from "path";
 
-// Try to read the CLI args from an RC file
-let rcFile: Record<string, any> | undefined;
-const argv = yargs.parseSync();
-const rcFileName: string = (argv.c as any) ?? ".releaseconfig.json";
-const rcFilePath = path.isAbsolute(rcFileName)
-	? rcFileName
-	: path.join(process.cwd(), rcFileName);
-if (fs.existsSync(rcFilePath)) {
-	try {
-		rcFile = require(rcFilePath);
-	} catch {}
+export async function parseArgs() {
+	// Try to read the CLI args from an RC file
+	let rcFile: Record<string, any> | undefined;
+	const argv = yargs.parseSync();
+	const rcFileName: string = (argv.c as any) ?? ".releaseconfig.json";
+	const rcFilePath = path.isAbsolute(rcFileName)
+		? rcFileName
+		: path.join(process.cwd(), rcFileName);
+	if (fs.existsSync(rcFilePath)) {
+		try {
+			rcFile = require(rcFilePath);
+		} catch {}
+	}
+
+	// Scripts can only provided through an RC file
+	const scripts: { [K in string]?: string | string[] } =
+		rcFile?.scripts ?? {};
+
+	// lerna mode offloads bumping the versions to lerna.
+	// it implies --all, since that is what lerna does
+	const lernaCheck: boolean =
+		(argv.lernaCheck as any) ??
+		argv["lerna-check"] ??
+		argv._.includes("--lerna-check");
+	const lerna: boolean =
+		lernaCheck ||
+		(rcFile?.lerna ?? argv.lerna ?? argv._.includes("--lerna"));
+
+	// remote repo, can be set by remote flag - else we let it be falsy
+	const remote: string = argv.r as any;
+
+	// in lerna mode, these have no effect
+	const isDryRun: boolean = (argv.dry as any) ?? argv._.includes("--dry");
+	const allChanges: boolean =
+		rcFile?.all ?? argv.all ?? argv._.includes("--all");
+
+	return { lernaCheck, lerna, isDryRun, allChanges, scripts, remote };
 }
-
-// Scripts can only provided through an RC file
-const scripts: {[K in string]?: string | string[]} = rcFile?.scripts ?? {};
-
-// lerna mode offloads bumping the versions to lerna.
-// it implies --all, since that is what lerna does
-const lernaCheck: boolean =
-	argv.lernaCheck as any ??
-	argv["lerna-check"] ??
-	argv._.includes("--lerna-check");
-const lerna: boolean =
-	lernaCheck || (rcFile?.lerna ?? argv.lerna ?? argv._.includes("--lerna"));
-
-// remote repo, can be set by remote flag - else we let it be falsy
-const remote: string = argv.r as any;
-
-// in lerna mode, these have no effect
-const isDryRun: boolean = (argv.dry as any) ?? argv._.includes("--dry");
-const allChanges: boolean = rcFile?.all ?? argv.all ?? argv._.includes("--all");
-
-export { lernaCheck, lerna, isDryRun, allChanges, scripts, remote };

--- a/src/parseArgs.ts
+++ b/src/parseArgs.ts
@@ -1,6 +1,7 @@
 import yargs from "yargs";
 import * as fs from "fs";
 import * as path from "path";
+import { isYarnWorkspace } from "./yarn";
 
 export async function parseArgs() {
 	// Try to read the CLI args from an RC file
@@ -20,23 +21,37 @@ export async function parseArgs() {
 	const scripts: { [K in string]?: string | string[] } =
 		rcFile?.scripts ?? {};
 
+	// remote repo, can be set by remote flag - else we let it be falsy
+	const remote: string | undefined = argv.r as any;
+
+	// yarn workspace with plugins is auto-detected
+	const yarnWorkspace = await isYarnWorkspace();
+
 	// lerna mode offloads bumping the versions to lerna.
 	// it implies --all, since that is what lerna does
-	const lernaCheck: boolean =
-		(argv.lernaCheck as any) ??
-		argv["lerna-check"] ??
-		argv._.includes("--lerna-check");
-	const lerna: boolean =
-		lernaCheck ||
-		(rcFile?.lerna ?? argv.lerna ?? argv._.includes("--lerna"));
-
-	// remote repo, can be set by remote flag - else we let it be falsy
-	const remote: string = argv.r as any;
+	// yarn workspaces implies NO lerna
+	const lernaCheck: boolean = yarnWorkspace
+		? false
+		: (argv.lernaCheck as any) ??
+		  argv["lerna-check"] ??
+		  argv._.includes("--lerna-check");
+	const lerna: boolean = yarnWorkspace
+		? false
+		: lernaCheck ||
+		  (rcFile?.lerna ?? argv.lerna ?? argv._.includes("--lerna"));
 
 	// in lerna mode, these have no effect
 	const isDryRun: boolean = (argv.dry as any) ?? argv._.includes("--dry");
 	const allChanges: boolean =
 		rcFile?.all ?? argv.all ?? argv._.includes("--all");
 
-	return { lernaCheck, lerna, isDryRun, allChanges, scripts, remote };
+	return {
+		lernaCheck,
+		lerna,
+		yarnWorkspace,
+		isDryRun,
+		allChanges,
+		scripts,
+		remote,
+	};
 }

--- a/src/release.ts
+++ b/src/release.ts
@@ -35,266 +35,277 @@ import {
 	splitChangelog,
 } from "./tools";
 import { translateText } from "./translate";
-import {
-	allChanges,
-	isDryRun,
-	lerna,
-	lernaCheck,
-	scripts as userScripts,
-	remote,
-} from "./parseArgs";
+import { parseArgs } from "./parseArgs";
 import { gitStatus } from "./gitStatus";
 
-const rootDir = process.cwd();
-const argv = yargs.parseSync();
+(async () => {
+	const rootDir = process.cwd();
+	const argv = yargs.parseSync();
+	const {
+		allChanges,
+		isDryRun,
+		lerna,
+		lernaCheck,
+		scripts: userScripts,
+		remote,
+	} = await parseArgs();
 
-function fail(reason: string): never {
-	console.error("");
-	console.error(colors.red("ERROR: " + reason));
-	console.error("");
-	process.exit(1);
-}
-
-// ensure that package.json exists and has a version (in lerna mode)
-const packPath = path.join(rootDir, "package.json");
-if (!fs.existsSync(packPath)) {
-	fail("No package.json found in the current directory!");
-}
-const pack = require(packPath);
-if (!lerna && !pack?.version) {
-	fail("Missing property version from package.json!");
-}
-
-const lernaPath = path.join(rootDir, "lerna.json");
-if (lerna && !fs.existsSync(lernaPath)) {
-	fail("No lerna.json found in the current directory!");
-}
-let lernaJson: Record<string, any> | undefined;
-if (lerna) {
-	lernaJson = require(lernaPath);
-	if (!lernaJson!.version) {
-		fail("Missing property version from lerna.json!");
+	function fail(reason: string): never {
+		console.error("");
+		console.error(colors.red("ERROR: " + reason));
+		console.error("");
+		process.exit(1);
 	}
-}
 
-// If this is an ioBroker project, also bump the io-package.json
-const ioPackPath = path.join(rootDir, "io-package.json");
-const hasIoPack = fs.existsSync(ioPackPath);
-const ioPack = hasIoPack ? require(ioPackPath) : undefined;
-if (!lerna && hasIoPack && !ioPack?.common?.version) {
-	fail("Missing property common.version from io-package.json!");
-}
-
-// Assume the repo is managed with yarn if there is a yarn.lock
-const isYarn = fs.existsSync(path.join(rootDir, "yarn.lock"));
-
-// Try to find the changelog
-let isChangelogInReadme = false;
-let CHANGELOG_PLACEHOLDER_PREFIX = "##";
-const changelogPath = path.join(rootDir, "CHANGELOG.md");
-const readmePath = path.join(rootDir, "README.md");
-/** Can also be the readme! */
-let changelog: string;
-let changelogFilename: string;
-if (!fs.existsSync(changelogPath)) {
-	// The changelog might be in the readme
-	if (!fs.existsSync(readmePath)) {
-		fail("No CHANGELOG.md or README.md found in the current directory!");
+	// ensure that package.json exists and has a version (in lerna mode)
+	const packPath = path.join(rootDir, "package.json");
+	if (!fs.existsSync(packPath)) {
+		fail("No package.json found in the current directory!");
 	}
-	isChangelogInReadme = true;
-	changelog = fs.readFileSync(readmePath, "utf8");
-	changelogFilename = path.basename(readmePath);
-	// The changelog is indented one more level in the readme
-	CHANGELOG_PLACEHOLDER_PREFIX += "#";
-} else {
-	changelog = fs.readFileSync(changelogPath, "utf8");
-	changelogFilename = path.basename(changelogPath);
-}
-// CHANGELOG_OLD is only used if the main changelog is in the readme
-const changelogOldPath = path.join(rootDir, "CHANGELOG_OLD.md");
-const hasChangelogOld = isChangelogInReadme && fs.existsSync(changelogOldPath);
+	const pack = require(packPath);
+	if (!lerna && !pack?.version) {
+		fail("Missing property version from package.json!");
+	}
 
-const CHANGELOG_MARKERS = ["**WORK IN PROGRESS**", "__WORK IN PROGRESS__"] as const;
-const CHANGELOG_PLACEHOLDER =
-	`${CHANGELOG_PLACEHOLDER_PREFIX} ${CHANGELOG_MARKERS[0]}`;
-// The regex for the placeholder includes an optional free text at the end, e.g.
-// ### __WORK IN PROGRESS__ "2020 Doomsday release"
-const CHANGELOG_PLACEHOLDER_REGEX = new RegExp(
-	`^${CHANGELOG_PLACEHOLDER_PREFIX} (?:${CHANGELOG_MARKERS.map(m => m.replace(/\*/g, "\\*")).join("|")})(.*?)$`,
-	"gm",
-);
+	const lernaPath = path.join(rootDir, "lerna.json");
+	if (lerna && !fs.existsSync(lernaPath)) {
+		fail("No lerna.json found in the current directory!");
+	}
+	let lernaJson: Record<string, any> | undefined;
+	if (lerna) {
+		lernaJson = require(lernaPath);
+		if (!lernaJson!.version) {
+			fail("Missing property version from lerna.json!");
+		}
+	}
 
-// check if the changelog contains exactly 1 occurence of the changelog placeholder
-switch ((changelog.match(CHANGELOG_PLACEHOLDER_REGEX) || []).length) {
-	case 0:
-		fail(
-			colors.red(
-				`Cannot continue, the changelog placeholder is missing from ${changelogFilename}!\n` +
-					"Please add the following line to your changelog:\n" +
-					CHANGELOG_PLACEHOLDER,
-			),
-		);
-	case 1:
-		break; // all good
-	default:
-		fail(
-			colors.red(
-				`Cannot continue, there is more than one changelog placeholder in ${changelogFilename}!`,
-			),
-		);
-}
+	// If this is an ioBroker project, also bump the io-package.json
+	const ioPackPath = path.join(rootDir, "io-package.json");
+	const hasIoPack = fs.existsSync(ioPackPath);
+	const ioPack = hasIoPack ? require(ioPackPath) : undefined;
+	if (!lerna && hasIoPack && !ioPack?.common?.version) {
+		fail("Missing property common.version from io-package.json!");
+	}
 
-// Check if there is a changelog for the current version
-const currentChangelog = extractCurrentChangelog(
-	changelog,
-	CHANGELOG_PLACEHOLDER_PREFIX,
-	CHANGELOG_PLACEHOLDER_REGEX,
-);
-if (!currentChangelog) {
-	fail(
-		colors.red(
-			"Cannot continue, the changelog for the next version is empty!",
-		),
+	// Assume the repo is managed with yarn if there is a yarn.lock
+	const isYarn = fs.existsSync(path.join(rootDir, "yarn.lock"));
+
+	// Try to find the changelog
+	let isChangelogInReadme = false;
+	let CHANGELOG_PLACEHOLDER_PREFIX = "##";
+	const changelogPath = path.join(rootDir, "CHANGELOG.md");
+	const readmePath = path.join(rootDir, "README.md");
+	/** Can also be the readme! */
+	let changelog: string;
+	let changelogFilename: string;
+	if (!fs.existsSync(changelogPath)) {
+		// The changelog might be in the readme
+		if (!fs.existsSync(readmePath)) {
+			fail(
+				"No CHANGELOG.md or README.md found in the current directory!",
+			);
+		}
+		isChangelogInReadme = true;
+		changelog = fs.readFileSync(readmePath, "utf8");
+		changelogFilename = path.basename(readmePath);
+		// The changelog is indented one more level in the readme
+		CHANGELOG_PLACEHOLDER_PREFIX += "#";
+	} else {
+		changelog = fs.readFileSync(changelogPath, "utf8");
+		changelogFilename = path.basename(changelogPath);
+	}
+	// CHANGELOG_OLD is only used if the main changelog is in the readme
+	const changelogOldPath = path.join(rootDir, "CHANGELOG_OLD.md");
+	const hasChangelogOld =
+		isChangelogInReadme && fs.existsSync(changelogOldPath);
+
+	const CHANGELOG_MARKERS = [
+		"**WORK IN PROGRESS**",
+		"__WORK IN PROGRESS__",
+	] as const;
+	const CHANGELOG_PLACEHOLDER = `${CHANGELOG_PLACEHOLDER_PREFIX} ${CHANGELOG_MARKERS[0]}`;
+	// The regex for the placeholder includes an optional free text at the end, e.g.
+	// ### __WORK IN PROGRESS__ "2020 Doomsday release"
+	const CHANGELOG_PLACEHOLDER_REGEX = new RegExp(
+		`^${CHANGELOG_PLACEHOLDER_PREFIX} (?:${CHANGELOG_MARKERS.map((m) =>
+			m.replace(/\*/g, "\\*"),
+		).join("|")})(.*?)$`,
+		"gm",
 	);
-}
 
-// check if there are untracked changes
-const branchStatus = gitStatus(rootDir);
-if (branchStatus === "diverged") {
-	if (!isDryRun) {
+	// check if the changelog contains exactly 1 occurence of the changelog placeholder
+	switch ((changelog.match(CHANGELOG_PLACEHOLDER_REGEX) || []).length) {
+		case 0:
+			fail(
+				colors.red(
+					`Cannot continue, the changelog placeholder is missing from ${changelogFilename}!\n` +
+						"Please add the following line to your changelog:\n" +
+						CHANGELOG_PLACEHOLDER,
+				),
+			);
+		case 1:
+			break; // all good
+		default:
+			fail(
+				colors.red(
+					`Cannot continue, there is more than one changelog placeholder in ${changelogFilename}!`,
+				),
+			);
+	}
+
+	// Check if there is a changelog for the current version
+	const currentChangelog = extractCurrentChangelog(
+		changelog,
+		CHANGELOG_PLACEHOLDER_PREFIX,
+		CHANGELOG_PLACEHOLDER_REGEX,
+	);
+	if (!currentChangelog) {
 		fail(
 			colors.red(
-				"Cannot continue, both the remote and the local repo have different changes! Please merge the remote changes first.",
-			),
-		);
-	} else {
-		console.log(
-			colors.red(
-				"This is a dry run. The full run would fail due to a diverged branch\n",
+				"Cannot continue, the changelog for the next version is empty!",
 			),
 		);
 	}
-} else if (branchStatus === "behind") {
-	if (!isDryRun) {
-		fail(
-			colors.red(
-				`Cannot continue, the local branch is behind the remote changes! Please include them first, e.g. with "git pull".`,
-			),
-		);
-	} else {
-		console.log(
-			colors.red(
-				"This is a dry run. The full run would fail due to the local branch being behind\n",
-			),
-		);
-	}
-} else if (branchStatus === "ahead" || branchStatus === "up-to-date") {
-	// all good
-	if (!lerna) {
-		console.log(colors.green("git status is good - I can continue..."));
-	}
-} else if (branchStatus === "uncommitted" && !lerna) {
-	if (!isDryRun && !allChanges) {
-		fail(
-			colors.red(
-				`Cannot continue, the local branch has uncommitted changes! Add them to a separate commit first or add the "--all" option to include them in the release commit.`,
-			),
-		);
-	} else {
-		if (allChanges) {
-			console.warn(
-				colors.yellow(
-					`Your branch has uncommitted changes that will be included in the release commit!
-Consider adding them to a separate commit first.
-`,
+
+	// check if there are untracked changes
+	const branchStatus = gitStatus(rootDir);
+	if (branchStatus === "diverged") {
+		if (!isDryRun) {
+			fail(
+				colors.red(
+					"Cannot continue, both the remote and the local repo have different changes! Please merge the remote changes first.",
 				),
 			);
 		} else {
 			console.log(
 				colors.red(
-					`This is a dry run. The full run would fail due to uncommitted changes.
-Add them to a separate commit first or add the "--all" option to include them in the release commit.
-`,
+					"This is a dry run. The full run would fail due to a diverged branch\n",
 				),
 			);
 		}
-	}
-}
-
-// All the necessary checks are done, exit
-if (lernaCheck) process.exit(0);
-
-const releaseTypes = [
-	"major",
-	"premajor",
-	"minor",
-	"preminor",
-	"patch",
-	"prepatch",
-	"prerelease",
-];
-
-const releaseType = (argv._[0] || "patch").toString();
-if (!lerna && releaseType.startsWith("--")) {
-	fail(
-		`Invalid release type ${releaseType}. If you meant to pass hyphenated args, try again without the single "--".`,
-	);
-}
-let newVersion: string | null;
-if (lerna) {
-	newVersion = lernaJson!.version;
-} else {
-	// Find the highest current version
-	let oldVersion = pack.version as string;
-	if (
-		hasIoPack &&
-		semver.valid(ioPack.common.version) &&
-		semver.gt(ioPack.common.version, oldVersion)
-	) {
-		oldVersion = ioPack.common.version;
-	}
-
-	if (releaseTypes.indexOf(releaseType) > -1) {
-		if (releaseType.startsWith("pre") && argv._.length >= 2) {
-			// increment to pre-release with an additional prerelease string
-			newVersion = semver.inc(
-				oldVersion,
-				releaseType as any,
-				argv._[1]?.toString(),
-			)!;
+	} else if (branchStatus === "behind") {
+		if (!isDryRun) {
+			fail(
+				colors.red(
+					`Cannot continue, the local branch is behind the remote changes! Please include them first, e.g. with "git pull".`,
+				),
+			);
 		} else {
-			newVersion = semver.inc(oldVersion, releaseType as any)!;
+			console.log(
+				colors.red(
+					"This is a dry run. The full run would fail due to the local branch being behind\n",
+				),
+			);
 		}
-		console.log(
-			`bumping version ${colors.blue(oldVersion)} to ${colors.gray(
-				releaseType,
-			)} version ${colors.green(newVersion)}\n`,
+	} else if (branchStatus === "ahead" || branchStatus === "up-to-date") {
+		// all good
+		if (!lerna) {
+			console.log(colors.green("git status is good - I can continue..."));
+		}
+	} else if (branchStatus === "uncommitted" && !lerna) {
+		if (!isDryRun && !allChanges) {
+			fail(
+				colors.red(
+					`Cannot continue, the local branch has uncommitted changes! Add them to a separate commit first or add the "--all" option to include them in the release commit.`,
+				),
+			);
+		} else {
+			if (allChanges) {
+				console.warn(
+					colors.yellow(
+						`Your branch has uncommitted changes that will be included in the release commit!
+Consider adding them to a separate commit first.
+`,
+					),
+				);
+			} else {
+				console.log(
+					colors.red(
+						`This is a dry run. The full run would fail due to uncommitted changes.
+Add them to a separate commit first or add the "--all" option to include them in the release commit.
+`,
+					),
+				);
+			}
+		}
+	}
+
+	// All the necessary checks are done, exit
+	if (lernaCheck) process.exit(0);
+
+	const releaseTypes = [
+		"major",
+		"premajor",
+		"minor",
+		"preminor",
+		"patch",
+		"prepatch",
+		"prerelease",
+	];
+
+	const releaseType = (argv._[0] || "patch").toString();
+	if (!lerna && releaseType.startsWith("--")) {
+		fail(
+			`Invalid release type ${releaseType}. If you meant to pass hyphenated args, try again without the single "--".`,
 		);
+	}
+	let newVersion: string | null;
+	if (lerna) {
+		newVersion = lernaJson!.version;
 	} else {
-		// increment to specific version
-		newVersion = semver.clean(releaseType);
-		if (newVersion == null) {
-			fail(`invalid version string "${newVersion}"`);
-		} else {
-			// valid version string => check if its actually newer
-			if (!semver.gt(newVersion, pack.version)) {
-				fail(
-					`new version ${newVersion} is NOT > than package.json version ${pack.version}`,
-				);
-			}
-			if (hasIoPack && !semver.gt(newVersion, ioPack.common.version)) {
-				fail(
-					`new version ${newVersion} is NOT > than io-package.json version ${ioPack.common.version}`,
-				);
-			}
+		// Find the highest current version
+		let oldVersion = pack.version as string;
+		if (
+			hasIoPack &&
+			semver.valid(ioPack.common.version) &&
+			semver.gt(ioPack.common.version, oldVersion)
+		) {
+			oldVersion = ioPack.common.version;
 		}
-		console.log(
-			`bumping version ${oldVersion} to specific version ${newVersion}`,
-		);
-	}
-}
 
-(async () => {
+		if (releaseTypes.indexOf(releaseType) > -1) {
+			if (releaseType.startsWith("pre") && argv._.length >= 2) {
+				// increment to pre-release with an additional prerelease string
+				newVersion = semver.inc(
+					oldVersion,
+					releaseType as any,
+					argv._[1]?.toString(),
+				)!;
+			} else {
+				newVersion = semver.inc(oldVersion, releaseType as any)!;
+			}
+			console.log(
+				`bumping version ${colors.blue(oldVersion)} to ${colors.gray(
+					releaseType,
+				)} version ${colors.green(newVersion)}\n`,
+			);
+		} else {
+			// increment to specific version
+			newVersion = semver.clean(releaseType);
+			if (newVersion == null) {
+				fail(`invalid version string "${newVersion}"`);
+			} else {
+				// valid version string => check if its actually newer
+				if (!semver.gt(newVersion, pack.version)) {
+					fail(
+						`new version ${newVersion} is NOT > than package.json version ${pack.version}`,
+					);
+				}
+				if (
+					hasIoPack &&
+					!semver.gt(newVersion, ioPack.common.version)
+				) {
+					fail(
+						`new version ${newVersion} is NOT > than io-package.json version ${ioPack.common.version}`,
+					);
+				}
+			}
+			console.log(
+				`bumping version ${oldVersion} to specific version ${newVersion}`,
+			);
+		}
+	}
+
 	if (isDryRun) {
 		console.log(colors.yellow("dry run:") + " not updating package files");
 	} else {

--- a/src/yarn.ts
+++ b/src/yarn.ts
@@ -1,0 +1,63 @@
+import { isArray } from "alcalzone-shared/typeguards";
+import execa from "execa";
+import fs from "fs-extra";
+import path from "path";
+import semver from "semver";
+
+/**
+ * Tests if the current workspace is using yarn with the version and workspace-tools plugin,
+ * which can be used to bump the versions
+ */
+export async function isYarnWorkspace(): Promise<boolean> {
+	// There should be a yarn.lock or yarn is not used
+	if (!(await fs.pathExists(path.join(process.cwd(), "yarn.lock")))) {
+		return false;
+	}
+
+	// package.json should contain a workspaces field
+	const packageJson = await fs.readJSON(
+		path.join(process.cwd(), "package.json"),
+		{ encoding: "utf8" },
+	);
+	if (!("workspaces" in packageJson && isArray(packageJson.workspaces))) {
+		return false;
+	}
+
+	// Check if yarn is used in at least version 2
+	const { stdout: yarnVersion } = await execa("yarn", ["-v"], {
+		reject: false,
+	});
+	if (!semver.valid(yarnVersion) || semver.lt(yarnVersion, "2.0.0")) {
+		return false;
+	}
+
+	// Check that the version plugin is there
+	const { stdout: plugins } = await execa(
+		"yarn",
+		["plugin", "runtime", "--json"],
+		{
+			reject: false,
+		},
+	);
+	return (
+		plugins.includes(`"@yarnpkg/plugin-version"`) &&
+		plugins.includes(`"@yarnpkg/plugin-workspace-tools"`)
+	);
+}
+
+export async function getChangedWorkspaces(): Promise<string[]> {
+	const { stdout: checkResult } = await execa("yarn", ["version", "check"], {
+		reject: false,
+	});
+
+	const matches = [
+		...checkResult.matchAll(
+			/ (?<workspace>@?[^ ]*?)@.+ has been modified but/g,
+		),
+	].map((match) => match.groups!.workspace!);
+	return matches;
+}
+
+export async function bump(workspace: string, type: string): Promise<void> {
+	await execa("yarn", ["workspace", workspace, "version", type]);
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,67 +1,7 @@
 {
+  "extends": "@tsconfig/node12/tsconfig.json",
   "compilerOptions": {
-    /* Basic Options */
-    // "incremental": true,                   /* Enable incremental compilation */
-    "target": "es2015",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */
-    "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
-    // "lib": [],                             /* Specify library files to be included in the compilation. */
-    // "allowJs": true,                       /* Allow javascript files to be compiled. */
-    // "checkJs": true,                       /* Report errors in .js files. */
-    // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
-    // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
-    // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
-    // "sourceMap": true,                     /* Generates corresponding '.map' file. */
-    // "outFile": "./",                       /* Concatenate and emit output to single file. */
-    "outDir": "./build",                        /* Redirect output structure to the directory. */
-    // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
-    // "composite": true,                     /* Enable project compilation */
-    // "tsBuildInfoFile": "./",               /* Specify file to store incremental compilation information */
-    // "removeComments": true,                /* Do not emit comments to output. */
-    // "noEmit": true,                        /* Do not emit outputs. */
-    // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
-    // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
-    // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
-
-    /* Strict Type-Checking Options */
-    "strict": true,                           /* Enable all strict type-checking options. */
-    // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
-    // "strictNullChecks": true,              /* Enable strict null checks. */
-    // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
-    // "strictBindCallApply": true,           /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
-    // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
-    // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
-    // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
-
-    /* Additional Checks */
-    // "noUnusedLocals": true,                /* Report errors on unused locals. */
-    // "noUnusedParameters": true,            /* Report errors on unused parameters. */
-    // "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
-    // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
-
-    /* Module Resolution Options */
-    // "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
-    // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
-    // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
-    // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
-    // "typeRoots": [],                       /* List of folders to include type definitions from. */
-    // "types": [],                           /* Type declaration files to be included in compilation. */
-    // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
-    "esModuleInterop": true,                  /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
-    // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
-    // "allowUmdGlobalAccess": true,          /* Allow accessing UMD globals from modules. */
-
-    /* Source Map Options */
-    // "sourceRoot": "",                      /* Specify the location where debugger should locate TypeScript files instead of source locations. */
-    // "mapRoot": "",                         /* Specify the location where debugger should locate map files instead of generated locations. */
-    // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
-    // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
-
-    /* Experimental Options */
-    // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
-    // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
-
-    /* Advanced Options */
-    "forceConsistentCasingInFileNames": true,  /* Disallow inconsistently-cased references to the same file. */
+    "outDir": "./build",
     "newLine": "lf"
   },
   "include": [


### PR DESCRIPTION
With this PR, release-script supports Yarn v2 workspaces if the `version` and `workspace-tools` plugins are used. In this setting, it can replace lerna.