### PR TITLE
fix: update test and release workflow in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,16 +237,17 @@ jobs:
         node-version: ${{ matrix.node-version }}
 
     - name: Extract the version and commit body from the tag
+      id: extract_release
       # The body may be multiline, therefore we need to escape some characters
       run: |
         VERSION="${{ github.ref }}"
         VERSION=${VERSION##*/v}
-        echo "::set-env name=VERSION::$VERSION"
+        echo "::set-output name=VERSION::$VERSION"
         BODY=$(git show -s --format=%b)
         BODY="${BODY//'%'/'%25'}"
         BODY="${BODY//$'\n'/'%0A'}"
         BODY="${BODY//$'\r'/'%0D'}"
-        echo "::set-env name=BODY::$BODY"
+        echo "::set-output name=BODY::$BODY"
 
     # If you are using TypeScript, additional build steps might be necessary
     # Run them here, e.g.:

--- a/README.md
+++ b/README.md
@@ -268,11 +268,11 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         tag_name: ${{ github.ref }}
-        release_name: Release v${{ env.VERSION }}
+        release_name: Release v${{ steps.extract_release.outputs.VERSION }}
         draft: false
         # Prerelease versions create prereleases on Github
-        prerelease: ${{ contains(env.VERSION, '-') }}
-        body: ${{ env.BODY }}
+        prerelease: ${{ contains(steps.extract_release.outputs.VERSION, '-') }}
+        body: ${{ steps.extract_release.outputs.BODY }}
 ```
 
 ## License


### PR DESCRIPTION
while set-env is deprecated