### PR TITLE
feat: implement rollback on failure

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -37,6 +37,7 @@
     "node": ">=12.20"
   },
   "dependencies": {
+    "alcalzone-shared": "^4.0.1",
     "execa": "^5.1.1"
   },
   "devDependencies": {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,6 +1,7 @@
 export { stripColors } from "./lib/cli";
 export * from "./lib/error";
 export * from "./lib/exec";
-export { execute, resolvePlugins } from "./lib/planner";
+export { execute, resolvePlugins, rollback } from "./lib/planner";
+export { cloneDeep } from "./lib/shared";
 export { DefaultStages } from "./lib/stage";
 export * from "./types";

--- a/packages/core/src/lib/context.ts
+++ b/packages/core/src/lib/context.ts
@@ -1,5 +1,6 @@
 import type { CLI } from "./cli";
 import type { Plugin } from "./plugin";
+import type { Stage } from "./stage";
 import type { System } from "./system";
 
 export interface Context {
@@ -43,4 +44,7 @@ export interface Context {
 	getData<T>(key: string): T;
 	hasData(key: string): boolean;
 	setData(key: string, value: any): void;
+
+	/** Keeps track of which stages have been fully or partially executed */
+	executedStages: Stage[];
 }

--- a/packages/core/src/lib/planner.test.ts
+++ b/packages/core/src/lib/planner.test.ts
@@ -347,6 +347,7 @@ describe("execute", () => {
 			},
 			argv: {},
 			errors: [],
+			executedStages: [],
 		} as unknown as Context;
 
 		await execute(context);

--- a/packages/core/src/lib/planner.ts
+++ b/packages/core/src/lib/planner.ts
@@ -167,6 +167,8 @@ export async function execute(context: Context): Promise<void> {
 	}
 	for (const stage of stages) {
 		context.cli.prefix = `${stage.id}`;
+		context.executedStages.push(stage);
+
 		const plugins = await planStage(context, stage);
 		if (context.argv.verbose) {
 			context.cli.log(
@@ -198,5 +200,16 @@ export async function execute(context: Context): Promise<void> {
 			}
 		}
 		if (!isTest) console.log();
+	}
+}
+
+/** Undo all the changes that have already been made to the file system */
+export async function rollback(context: Context): Promise<void> {
+	for (const plugin of context.plugins) {
+		try {
+			await plugin.rollback?.(context);
+		} catch {
+			// ignore
+		}
 	}
 }

--- a/packages/core/src/lib/plugin.ts
+++ b/packages/core/src/lib/plugin.ts
@@ -35,4 +35,7 @@ export interface Plugin {
 
 	/** Execute the plugin for the given stage */
 	executeStage(context: Context, stage: Stage): Promise<void>;
+
+	/** Reset the previous state in case of an execution error */
+	rollback?: (context: Context) => Promise<void> | void;
 }

--- a/packages/core/src/lib/shared.ts
+++ b/packages/core/src/lib/shared.ts
@@ -1,3 +1,21 @@
+import { isArray, isObject } from "alcalzone-shared/typeguards";
 import type { Context } from "./context";
 
 export type ConstOrDynamic<T> = T | ((context: Context) => T | Promise<T>);
+
+/**
+ * Creates a deep copy of the given object
+ */
+export function cloneDeep<T>(source: T): T {
+	if (isArray(source)) {
+		return source.map((i) => cloneDeep(i)) as any;
+	} else if (isObject(source)) {
+		const target: any = {};
+		for (const [key, value] of Object.entries(source)) {
+			target[key] = cloneDeep(value);
+		}
+		return target;
+	} else {
+		return source;
+	}
+}

--- a/packages/plugin-package/src/index.ts
+++ b/packages/plugin-package/src/index.ts
@@ -1,5 +1,5 @@
 import { detectPackageManager } from "@alcalzone/pak";
-import { DefaultStages } from "@alcalzone/release-script-core";
+import { cloneDeep, DefaultStages } from "@alcalzone/release-script-core";
 import type { Context, Plugin, Stage } from "@alcalzone/release-script-core/types";
 import { isArray, isObject } from "alcalzone-shared/typeguards";
 import fs from "fs-extra";
@@ -197,7 +197,7 @@ Alternatively, you can use ${context.cli.colors.blue("lerna")} to manage the mon
 
 	private async executeEditStage(context: Context): Promise<void> {
 		const newVersion = context.getData<string>("version_new");
-		const pack = context.getData<any>("package.json");
+		const pack = cloneDeep(context.getData<any>("package.json"));
 
 		if (context.argv.dryRun) {
 			context.cli.log(
@@ -332,6 +332,17 @@ Alternatively, you can use ${context.cli.colors.blue("lerna")} to manage the mon
 				}
 			}
 		}
+	}
+
+	async rollback(context: Context): Promise<void> {
+		if (!context.executedStages.some((s) => s.id === "edit")) {
+			// Nothing has been changed yet
+			return;
+		}
+
+		const pack = context.getData<Readonly<any>>("package.json");
+		const packPath = path.join(context.cwd, "package.json");
+		await fs.writeJson(packPath, pack, { spaces: 2 });
 	}
 }
 

--- a/packages/release-script/src/index.ts
+++ b/packages/release-script/src/index.ts
@@ -8,6 +8,7 @@ import {
 	Plugin,
 	ReleaseError,
 	resolvePlugins,
+	rollback,
 	SelectOption,
 	stripColors,
 } from "@alcalzone/release-script-core";
@@ -268,6 +269,7 @@ export async function main(): Promise<void> {
 		setData: (key: string, value: any) => {
 			data.set(key, value);
 		},
+		executedStages: [],
 	};
 	context.cli = new CLI(context);
 
@@ -295,6 +297,7 @@ export async function main(): Promise<void> {
 			message += "!";
 			console.error();
 			console.error(message);
+			await rollback(context);
 			process.exit(1);
 		}
 	} catch (e: any) {
@@ -318,6 +321,7 @@ export async function main(): Promise<void> {
 				),
 			);
 		}
+		await rollback(context);
 		process.exit((e as any).code ?? 1);
 	}
 }

--- a/packages/testing/src/lib/context.ts
+++ b/packages/testing/src/lib/context.ts
@@ -75,6 +75,7 @@ export const defaultContextOptions: Omit<
 	},
 	plugins: [],
 	sys: new MockSystem(),
+	executedStages: [],
 };
 
 export function createMockContext(

--- a/yarn.lock
+++ b/yarn.lock
@@ -21,6 +21,7 @@ __metadata:
   resolution: "@alcalzone/release-script-core@workspace:packages/core"
   dependencies:
     "@types/yargs": ^17.0.9
+    alcalzone-shared: ^4.0.1
     execa: ^5.1.1
     picocolors: 1.0.0
     typescript: ~4.6.2


### PR DESCRIPTION
With this PR, package.json, io-package.json and the README/CHANGELOG files are reset to the previous status if the release script aborts, e.g. due to a failed translation.

fixes: #126