### PR TITLE
additionalChangelog CLI option

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,6 +344,10 @@ Only applies when the changelog is in `README.md` and a `CHANGELOG_OLD.md` exist
 
 If you want the release script to add a new empty placeholder to the changelog after a release, this option is for you. By default, this is disabled.
 
+#### Add additional entries to the release changelog (`--additionalChangelog` or `--additional-changelog`)
+
+If you want the release script to add some more entry/entries to the changelog for the release. To add multiple just separate them using `\n` so f.e. `* Entry 1\n* Entry 2`.By default this does not add anything.
+
 ### `package` plugin options
 
 #### Don't synchronize the lockfile (`--no-update-lockfile`)

--- a/packages/plugin-changelog/src/index.test.ts
+++ b/packages/plugin-changelog/src/index.test.ts
@@ -60,6 +60,14 @@ stuff
 ### Subsection 2
 * New entry 4
 * New entry 5`,
+	changelog_testParseAdditionalChangelog1Without: `## **WORK IN PROGRESS** · Doomsday release
+* New entry 1
+* New entry 2`,
+	changelog_testParseAdditionalChangelog1With: `## **WORK IN PROGRESS** · Doomsday release
+* New entry 1
+* New entry 2
+* first Changelog entry added via cli-option
+* another CLI-Option Changelog entry`,
 };
 
 describe("Changelog plugin", () => {
@@ -264,6 +272,88 @@ ${fixtures.changelog_subsectionsParse2}`,
 			expect(currentChangelog).toBe(`### Subsection 1
 * New entry 1
 * New entry 2`);
+		});
+
+		it("parses all changelog entries correctly if additionalChangelog is set", async () => {
+			const changelogPlugin = new ChangelogPlugin();
+			const context = createMockContext({
+				plugins: [changelogPlugin],
+				cwd: testFSRoot,
+				argv: {
+					additionalChangelog: '* first Changelog entry added via cli-option\n* another CLI-Option Changelog entry',
+				}
+			});
+
+			await testFS.create({
+				"CHANGELOG.md": `${fixtures.changelog_testParseHeader}
+${fixtures.changelog_testParseAdditionalChangelog1Without}
+
+${fixtures.changelog_testParse2}
+
+${fixtures.changelog_testParse3}`,
+			});
+
+			await changelogPlugin.executeStage(context, DefaultStages.check);
+			expect(context.errors).toHaveLength(0);
+
+			const headline = context.getData<string[]>("changelog_before");
+			expect(headline).toBe(fixtures.changelog_testParseHeader + "\n");
+
+			const entries = context.getData<string[]>("changelog_entries");
+			expect(entries).toEqual([
+				fixtures.changelog_testParseAdditionalChangelog1With,
+				fixtures.changelog_testParse2,
+				fixtures.changelog_testParse3,
+			]);
+
+			const footer = context.getData<string[]>("changelog_after");
+			expect(footer).toBe("");
+
+			const currentChangelog = context.getData<string[]>("changelog_new");
+			expect(currentChangelog).toBe(`* New entry 1
+* New entry 2
+* first Changelog entry added via cli-option
+* another CLI-Option Changelog entry`);
+		});
+
+		it("even if no WIP section exists before", async () => {
+			const changelogPlugin = new ChangelogPlugin();
+			const context = createMockContext({
+				plugins: [changelogPlugin],
+				cwd: testFSRoot,
+				argv: {
+					additionalChangelog: '* first Changelog entry added via cli-option\n* another CLI-Option Changelog entry',
+				}
+			});
+
+			await testFS.create({
+				"CHANGELOG.md": `${fixtures.changelog_testParseHeader}
+${fixtures.changelog_testParse2}
+
+${fixtures.changelog_testParse3}`,
+			});
+
+			await changelogPlugin.executeStage(context, DefaultStages.check);
+			expect(context.errors).toHaveLength(0);
+
+			const headline = context.getData<string[]>("changelog_before");
+			expect(headline).toBe(fixtures.changelog_testParseHeader + "\n");
+
+			const entries = context.getData<string[]>("changelog_entries");
+			expect(entries).toEqual([
+				`## **WORK IN PROGRESS**
+* first Changelog entry added via cli-option
+* another CLI-Option Changelog entry`,
+				fixtures.changelog_testParse2,
+				fixtures.changelog_testParse3,
+			]);
+
+			const footer = context.getData<string[]>("changelog_after");
+			expect(footer).toBe("");
+
+			const currentChangelog = context.getData<string[]>("changelog_new");
+			expect(currentChangelog).toBe(`* first Changelog entry added via cli-option
+* another CLI-Option Changelog entry`);
 		});
 
 		it("Detects final newlines correctly", async () => {

--- a/packages/plugin-changelog/src/index.ts
+++ b/packages/plugin-changelog/src/index.ts
@@ -113,6 +113,11 @@ class ChangelogPlugin implements Plugin {
 				description: `Add an empty placeholder to the changelog after a release.`,
 				default: false,
 			},
+			additionalChangelog: {
+				alias: ["additional-changelog"],
+				type: "string",
+				description: `Add additional changelog entry/entries to the release.`
+			}
 		});
 	}
 
@@ -183,7 +188,17 @@ class ChangelogPlugin implements Plugin {
 		// But we only output the primary one
 		const changelogPlaceholder = `${changelogPlaceholderPrefix} ${changelogMarkers[0]}`;
 
+		if(context.argv.additionalChangelog) {
+			let currentChangelogsIndex = entries.findIndex((e) => getPlaceholderRegex().test(e));
+			if (currentChangelogsIndex == -1) {
+				entries.unshift('## **WORK IN PROGRESS**');
+				currentChangelogsIndex = 0
+			}
+			entries[currentChangelogsIndex] += `\n${context.argv.additionalChangelog}`;
+		}
+
 		const currentChangelogs = entries.filter((e) => getPlaceholderRegex().test(e));
+
 		switch (currentChangelogs.length) {
 			case 0:
 				context.cli.error(

--- a/packages/plugin-changelog/src/index.ts
+++ b/packages/plugin-changelog/src/index.ts
@@ -191,7 +191,7 @@ class ChangelogPlugin implements Plugin {
 		if(context.argv.additionalChangelog) {
 			let currentChangelogsIndex = entries.findIndex((e) => getPlaceholderRegex().test(e));
 			if (currentChangelogsIndex == -1) {
-				entries.unshift('## **WORK IN PROGRESS**');
+				entries.unshift(changelogPlaceholder);
 				currentChangelogsIndex = 0
 			}
 			entries[currentChangelogsIndex] += `\n${context.argv.additionalChangelog}`;


### PR DESCRIPTION
This adds a new optional cli option to the changelog plugin to specify (additional) changelog information directly from the cli, without adding it first to the WIP section in the README/Changelog file.

Why would this be useful:
We currently plan on adding automatic releases to the iobroker-esphome adapter after a dependency change.  (More information here: https://github.com/DrozmotiX/ioBroker.esphome/issues/118) Having this would allow to just run the release-script and add the dynamic release-information automatically without having to parse / update the README twice (adding release-info to WIP and then change again using release-script).
And I think this could also be useful for other projects with CI stuff.