### PR TITLE
fix: set unicode flag for author name regex

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,7 +4,7 @@
 	"editor.defaultFormatter": "esbenp.prettier-vscode",
 	"[typescript]": {
 		"editor.codeActionsOnSave": {
-			"source.organizeImports": true
+			"source.organizeImports": "explicit"
 		}
 	},
 	"jest.jestCommandLine": "yarn test",

--- a/packages/plugin-iobroker/src/tools.test.ts
+++ b/packages/plugin-iobroker/src/tools.test.ts
@@ -1,0 +1,27 @@
+import { cleanChangelogForNews } from "./tools";
+
+describe("cleanChangelogForNews", () => {
+	it("removes author names with umlauts", () => {
+		const input = `
+* (Jürgen) Line 1
+* (Jérôme) Line 2
+* (René) Line 3
+* (Burić) Line 4
+* (Çoban) Line 5
+* (Jörg) Line 6
+* (Keßler) Line 7
+`.trim();
+
+		const expected = `
+Line 1
+Line 2
+Line 3
+Line 4
+Line 5
+Line 6
+Line 7
+`.trim();
+
+		expect(cleanChangelogForNews(input)).toBe(expected);
+	});
+});

--- a/packages/plugin-iobroker/src/tools.ts
+++ b/packages/plugin-iobroker/src/tools.ts
@@ -14,7 +14,7 @@ export function limitKeys<T>(obj: Record<string, T>, count: number): Record<stri
 	return ret;
 }
 
-const changelogAuthorRegex = /^[ \t]*[\*\-][ \t]*\([\p{L}\p{M}0-9@\-_,;&\+\/ ]+\)[ \t]*/gim;
+const changelogAuthorRegex = /^[ \t]*[\*\-][ \t]*\([\p{L}\p{M}0-9@\-_,;&\+\/ ]+\)[ \t]*/gimu;
 const changelogBulletPointTestRegex = /^[ \t]*[\*\-][ \t]*/;
 const changelogBulletPointReplaceRegex = new RegExp(changelogBulletPointTestRegex, "mg");
 


### PR DESCRIPTION
#161 forgot to set the unicode flag `u` for the Regex, which caused the unicode character classes to be treated as `p`, `{`, etc.