### PR TITLE
fix: yarn v4 support for monorepos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
     Placeholder for the next version (at the beginning of the line):
     ## **WORK IN PROGRESS**
 -->
+## **WORK IN PROGRESS**
+* `package` plugin: Support monorepos managed with Yarn v4
+
 ## 3.7.2 (2024-06-24)
 * `iobroker` plugin: Fixed issue in changelog cleanup routine introduced in `3.7.1`
 

--- a/packages/plugin-package/src/index.test.ts
+++ b/packages/plugin-package/src/index.test.ts
@@ -170,6 +170,11 @@ describe("Package plugin", () => {
 				".yarnrc.yml": fixtures.yarnrc_commented_out,
 			});
 
+			context.sys.mockExec((cmd) => {
+				if (cmd === "yarn --version") return "3.4.5";
+				return "";
+			});
+
 			await assertReleaseError(() => pkgPlugin.executeStage(context, DefaultStages.check), {
 				fatal: true,
 				messageMatches: /plugin import version/i,
@@ -240,11 +245,10 @@ describe("Package plugin", () => {
 			context.setData("version_new", newVersion);
 			context.setData("monorepo", "yarn");
 
-			context.sys.mockExec((cmd) =>
-				cmd.includes("changed list")
-					? "" // no changes!
-					: "",
-			);
+			context.sys.mockExec((cmd) => {
+				if (cmd === "yarn --version") return "3.4.5";
+				return "";
+			});
 
 			await assertReleaseError(() => pkgPlugin.executeStage(context, DefaultStages.check), {
 				fatal: true,
@@ -405,6 +409,7 @@ describe("Package plugin", () => {
 					"yarn",
 					"changed",
 					"foreach",
+					"--all",
 					`--git-range=v${pack.version}`,
 					"version",
 					newVersion,


### PR DESCRIPTION
Since Yarn v4, the plugins `version` and `workspace-tools` are included by default.