### PR TITLE
ci: bump action pins in test-and-release workflow

### DIFF
--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Enable Corepack
         shell: bash
@@ -59,7 +59,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Enable Corepack
         shell: bash
@@ -95,7 +95,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Enable Corepack
         shell: bash
@@ -137,7 +137,7 @@ jobs:
         run: yarn workspaces foreach --all -vti --no-private npm publish --tolerate-republish $TAG
 
       - name: Create Github Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
The workflow was already largely modernized in earlier PRs (#192, #203, and the Windows-testing removal) — it already has OIDC-based publishing, the `permissions:` block, `$GITHUB_OUTPUT`, a Node `[22, 24]` matrix with no EOL versions, and no `[skip ci]` guards.

This PR just picks up the remaining action-pin bumps to match the version policy already rolled out in AlCalzone/jsonl-db, zwave-js/waddle and AlCalzone/node-coap-client:

- `actions/checkout@v6` -> `v7` (all three jobs)
- `softprops/action-gh-release@v2` -> `v3` (deploy job)

No other changes — `actions/setup-node@v6`, the Node matrix, the `yarn workspaces foreach --all -vti --no-private npm publish` OIDC publish step, and the `packageManager: yarn@4.12.0` pin were already at or ahead of the target standard, so left untouched.